### PR TITLE
fix: Offsets changes after CS:S 18.02.25 update

### DIFF
--- a/addons/sourcemod/gamedata/firebulletsfix.games.txt
+++ b/addons/sourcemod/gamedata/firebulletsfix.games.txt
@@ -6,9 +6,9 @@
 		{
 			"Weapon_ShootPosition"
 			{
-				"windows"	"265"
-				"linux"		"266"
-				"mac"		"266"
+				"windows"	"271"
+				"linux"		"272"
+				"mac"		"272"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/firebulletsfix.sp
+++ b/addons/sourcemod/scripting/firebulletsfix.sp
@@ -13,7 +13,7 @@ public Plugin myinfo =
 	name = "Bullet position fix",
 	author = "xutaxkamay",
 	description = "Fixes shoot position",
-	version = "1.0.1",
+	version = "1.1.0",
 	url = "https://forums.alliedmods.net/showthread.php?p=2646571"
 };
 


### PR DESCRIPTION
## Old 
![image](https://github.com/user-attachments/assets/6ff083f0-dc3a-4519-bf69-06d92d8e4435)

## New
![image](https://github.com/user-attachments/assets/15155537-b42f-414f-b2a6-485d7a9960a8)

-> Tested and seem to work as excepted (untested signature for windows)